### PR TITLE
Fix called property name ($this->params)

### DIFF
--- a/src/Imagekit.php
+++ b/src/Imagekit.php
@@ -183,7 +183,7 @@ class Imagekit extends Tags
     {
         $imagekitParams = [];
 
-        foreach ($this->parameters as $param => $value) {
+        foreach ($this->params as $param => $value) {
             if (!in_array($param, $this->tagAttrs)) {
                 $imagekitParams[$param] = $value;
             }


### PR DESCRIPTION
The `$parameters` property was removed in Tags.php